### PR TITLE
Fix for nodes (shape & color) not displaying correctly in Safari

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -82,7 +82,9 @@ function createChart({
             text.textContent = d.id;
             const circle = node.querySelector('circle');
             circle.style.fill = color(d.id);
-            circle.style.r = d.id.length * 14;
+            console.log('Color for id:', d.id, color(d.id));
+            circle.r.baseVal.value = d.id.length * 14; 
+            // circle.style.r = d.id.length * 14;
             const isFirstNode = d.index === 0;
             if (isFirstNode) {
               node.classList.add('first-node');


### PR DESCRIPTION
Description:

This pull request addresses an issue where the nodes' colors and shapes in the Idioms Solitaire game were not rendering properly in Safari.

The root of this problem seems to stem from the way the radius attribute of the circles is being set in the D3.js code. In Safari,` circle.style.r` does not work as expected, which leads to the issue.


Steps to reproduce:

Open Safari.(iPhone Safari with URL , Mac Safari with your URL and Mac local  )
Observe that the nodes' colors and shapes are not visible.

![Displaying err](https://github.com/CodeSteppe/idioms-solitaire/assets/45887805/726ea631-94a7-4d4f-aa32-118b9a4ff036)
![Mobile displaying err](https://github.com/CodeSteppe/idioms-solitaire/assets/45887805/c3a5ec44-5dc1-4d3a-86f2-4816d88b00d2)


Expected behavior:

The nodes should be colored according to their respective groups and the shapes should be clearly visible.


To resolve this problem, I've made the following changes in the code:

Replaced `circle.style.r = d.id.length * 14; `with `circle.r.baseVal.value = d.id.length * 14;`
This change enables the correct rendering of nodes in Safari. Please review and let me know if any further changes are required.